### PR TITLE
Query transaction with a summary -- Du Chenglong

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Please initialize database with [this sql file](./src/main/resources/sql/citi.sq
 
 ## Request example
 
-### Query transaction records
+### Query transaction records in one day
 
-Query transaction records using “TransactionView”.
+*Query transaction records using* `TransactionView`.
 
-For example, query all transaction:
+Query transaction record for a certain time period (such as 1 day):
 
-GET: `http://127.0.0.1:8081/transaction_view`
+GET: `http://127.0.0.1:8081/transaction_view/1D`
 
 Response:
 
@@ -24,7 +24,7 @@ Response:
     "message": "成功!",
     "data": [
         {
-            "date": "2022-08-25",
+            "date": "2022-08-29",
             "ticker": "不存在的企业",
             "ric": "fake",
             "size": 10,
@@ -55,9 +55,9 @@ Response:
 }
 ```
 
-Query transaction record for a certain time period (such as 1 day):
+Query transaction summary in 1 day:
 
-GET: `http://127.0.0.1:8081/transaction_view/1D`
+GET: `http://127.0.0.1:8081/transaction_view/summary/1D`
 
 Response:
 
@@ -65,24 +65,56 @@ Response:
 {
     "status": 200,
     "message": "成功!",
-    "data": [
-        {
-            "date": "2022-08-29",
-            "ticker": "不存在的企业",
-            "ric": "fake",
-            "size": 10,
-            "price": 10.0,
-            "currency": "CNY",
-            "salesperson": "salesman1",
-            "client_name": "用户1号",
-            "client_side": 1,
-            "notional_usd": 1.4705881940452297,
-            "issuer_sector": "Sector1",
-            "ht_pt": 1
-        }
-    ]
+    "data": {
+        "total_buy": 200.0,
+        "total_sell": 0.0,
+        "quantity": 200.0,
+        "buy_notional": 29.411763880904594,
+        "sell_notional": 0.0,
+        "net_notional": 29.411763880904594,
+        "list": [
+            {
+                "date": "2022-08-29",
+                "ticker": "不存在的企业",
+                "ric": "fake",
+                "size": 10,
+                "price": 10.0,
+                "currency": "CNY",
+                "salesperson": "salesman1",
+                "client_name": "用户1号",
+                "client_side": 1,
+                "notional_usd": 1.4705881940452297,
+                "issuer_sector": "Sector1",
+                "ht_pt": 1
+            },
+            {
+                "date": "2022-08-29",
+                "ticker": "不存在的企业",
+                "ric": "fake",
+                "size": 10,
+                "price": 10.0,
+                "currency": "CNY",
+                "salesperson": "salesman1",
+                "client_name": "用户1号",
+                "client_side": 1,
+                "notional_usd": 1.4705881940452297,
+                "issuer_sector": "Sector1",
+                "ht_pt": 1
+            }
+        ]
+    }
 }
 ```
+
+Others:
+
+Query all transaction records:
+
+GET: `http://127.0.0.1:8081/transaction_view`
+
+Query transaction summary for all records:
+
+GET: `http://127.0.0.1:8081/transaction_view/summary`
 
 ### Insert a transaction record
 

--- a/src/main/java/com/citi/training/groupb/servicedemo/controller/TransactionViewController.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/controller/TransactionViewController.java
@@ -23,12 +23,22 @@ public class TransactionViewController {
 
     @RequestMapping(method = RequestMethod.GET, path = "/transaction_view")
     public Result<Object> getTransactionView() {
-        return ResultResponse.getSuccessResult(transactionViewService.getAllTransaction());
+        return ResultResponse.getSuccessResult(transactionViewService.getTransactionInTime("All"));
     }
 
     @RequestMapping(method = RequestMethod.GET, path ="/transaction_view/{timeGap}")
     public Result<Object> getTransactionView(@PathVariable String timeGap) {
         return ResultResponse.getSuccessResult(transactionViewService.getTransactionInTime(timeGap));
+    }
+
+    @RequestMapping(method = RequestMethod.GET, path = "/transaction_view/summary")
+    public Result<Object> getTransactionSummary() {
+        return ResultResponse.getSuccessResult(transactionViewService.getTransactionSummaryInTime("All"));
+    }
+
+    @RequestMapping(method = RequestMethod.GET, path = "/transaction_view/summary/{timeGap}")
+    public Result<Object> getTransactionSummary(@PathVariable String timeGap) {
+        return ResultResponse.getSuccessResult(transactionViewService.getTransactionSummaryInTime(timeGap));
     }
 
 }

--- a/src/main/java/com/citi/training/groupb/servicedemo/entity/TransactionView.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/entity/TransactionView.java
@@ -73,7 +73,7 @@ public class TransactionView implements Serializable {
 
     @TableField("notional_usd")
     @JsonProperty("notional_usd")
-    private Object notionalUsd;
+    private Double notionalUsd;
 
     /**
      * 货币名称

--- a/src/main/java/com/citi/training/groupb/servicedemo/service/TransactionViewService.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/service/TransactionViewService.java
@@ -2,6 +2,7 @@ package com.citi.training.groupb.servicedemo.service;
 
 import com.citi.training.groupb.servicedemo.entity.TransactionView;
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.citi.training.groupb.servicedemo.vo.TransactionSummary;
 
 import java.util.List;
 
@@ -14,8 +15,8 @@ import java.util.List;
  * @since 2022-08-25
  */
 public interface TransactionViewService extends IService<TransactionView> {
-    List<TransactionView> getAllTransaction();
 
     List<TransactionView> getTransactionInTime(String timeGap);
 
+    public TransactionSummary getTransactionSummaryInTime(String timeGap);
 }

--- a/src/main/java/com/citi/training/groupb/servicedemo/service/impl/TransactionViewServiceImpl.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/service/impl/TransactionViewServiceImpl.java
@@ -4,10 +4,12 @@ import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.citi.training.groupb.servicedemo.entity.TransactionView;
 import com.citi.training.groupb.servicedemo.mapper.TransactionViewMapper;
 import com.citi.training.groupb.servicedemo.service.TransactionViewService;
+import com.citi.training.groupb.servicedemo.vo.TransactionSummary;
 import org.springframework.stereotype.Service;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -26,10 +28,6 @@ public class TransactionViewServiceImpl extends ServiceImpl<TransactionViewMappe
         this.transactionViewMapper = transactionViewMapper;
     }
 
-    public List<TransactionView> getAllTransaction() {
-        return transactionViewMapper.selectAll();
-    }
-
     @Override
     public List<TransactionView> getTransactionInTime(String timeGap) {
         Calendar calendar = Calendar.getInstance();
@@ -42,12 +40,34 @@ public class TransactionViewServiceImpl extends ServiceImpl<TransactionViewMappe
             case "3M" -> calendar.add(Calendar.MONTH, -3);
             case "6M" -> calendar.add(Calendar.MONTH, -6);
             case "1Y" -> calendar.add(Calendar.YEAR, -1);
+            case "YTD" -> calendar.set(calendar.get(Calendar.YEAR), Calendar.JANUARY, 1);
             default -> {
-                return getAllTransaction();
+                return transactionViewMapper.selectAll();
             }
         }
         String start_date = dateFormat.format(calendar.getTime());
         return transactionViewMapper.selectBeforeDate(start_date);
     }
 
+    @Override
+    public TransactionSummary getTransactionSummaryInTime(String timeGap) {
+        List<TransactionView> list = getTransactionInTime(timeGap);
+        TransactionSummary summary = new TransactionSummary(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, list);
+        summary.setList(list);
+
+        for (TransactionView transaction : list) {
+            Double totalPrice = transaction.getPrice() * transaction.getSize();
+            Double totalNotional = transaction.getNotionalUsd() * transaction.getSize();
+            if (transaction.getClientSide() == 0) {
+                summary.setTotalSell(summary.getTotalSell() + totalPrice);
+                summary.setSellNotional(summary.getSellNotional() + totalNotional);
+            } else {
+                summary.setTotalBuy(summary.getTotalBuy() + totalPrice);
+                summary.setBuyNotional(summary.getBuyNotional() + totalNotional);
+            }
+        }
+        summary.setQuantity(summary.getTotalBuy() - summary.getTotalSell());
+        summary.setNetNotional(summary.getBuyNotional() - summary.getSellNotional());
+        return summary;
+    }
 }

--- a/src/main/java/com/citi/training/groupb/servicedemo/vo/TransactionRequest.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/vo/TransactionRequest.java
@@ -10,8 +10,6 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Data
-@Getter
-@Setter
 public class TransactionRequest {
 
     @JsonProperty("client_name")

--- a/src/main/java/com/citi/training/groupb/servicedemo/vo/TransactionSummary.java
+++ b/src/main/java/com/citi/training/groupb/servicedemo/vo/TransactionSummary.java
@@ -1,0 +1,32 @@
+package com.citi.training.groupb.servicedemo.vo;
+
+import com.citi.training.groupb.servicedemo.entity.TransactionView;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class TransactionSummary {
+    @JsonProperty("total_buy")
+    private Double totalBuy;
+
+    @JsonProperty("total_sell")
+    private Double totalSell;
+
+    @JsonProperty("quantity")
+    private Double quantity;
+
+    @JsonProperty("buy_notional")
+    private Double buyNotional;
+
+    @JsonProperty("sell_notional")
+    private Double sellNotional;
+
+    @JsonProperty("net_notional")
+    private Double netNotional;
+
+    @JsonProperty("list")
+    private List<TransactionView> list;
+}


### PR DESCRIPTION
## Changes

Now we can query transaction **with a summary** for a certain time period (such as 1 day):

GET: `http://127.0.0.1:8081/transaction_view/summary/1D`

Response:

```json
{
    "status": 200,
    "message": "成功!",
    "data": {
        "total_buy": 200.0,
        "total_sell": 0.0,
        "quantity": 200.0,
        "buy_notional": 29.411763880904594,
        "sell_notional": 0.0,
        "net_notional": 29.411763880904594,
        "list": [
            {
                "date": "2022-08-29",
                "ticker": "不存在的企业",
                "ric": "fake",
                "size": 10,
                "price": 10.0,
                "currency": "CNY",
                "salesperson": "salesman1",
                "client_name": "用户1号",
                "client_side": 1,
                "notional_usd": 1.4705881940452297,
                "issuer_sector": "Sector1",
                "ht_pt": 1
            },
            {
                "date": "2022-08-29",
                "ticker": "不存在的企业",
                "ric": "fake",
                "size": 10,
                "price": 10.0,
                "currency": "CNY",
                "salesperson": "salesman1",
                "client_name": "用户1号",
                "client_side": 1,
                "notional_usd": 1.4705881940452297,
                "issuer_sector": "Sector1",
                "ht_pt": 1
            }
        ]
    }
}
```

Querying without a summary is still available: query transaction record for a certain time period (such as 1 day):

GET: `http://127.0.0.1:8081/transaction_view/1D`

Response:

```json
{
    "status": 200,
    "message": "成功!",
    "data": [
        {
            "date": "2022-08-29",
            "ticker": "不存在的企业",
            "ric": "fake",
            "size": 10,
            "price": 10.0,
            "currency": "CNY",
            "salesperson": "salesman1",
            "client_name": "用户1号",
            "client_side": 1,
            "notional_usd": 1.4705881940452297,
            "issuer_sector": "Sector1",
            "ht_pt": 1
        },
        {
            "date": "2022-08-29",
            "ticker": "不存在的企业",
            "ric": "fake",
            "size": 10,
            "price": 10.0,
            "currency": "CNY",
            "salesperson": "salesman1",
            "client_name": "用户1号",
            "client_side": 1,
            "notional_usd": 1.4705881940452297,
            "issuer_sector": "Sector1",
            "ht_pt": 1
        }
    ]
}
```

Other examples:

Query all transaction records:

GET: `http://127.0.0.1:8081/transaction_view`

Query transaction summary for all records:

GET: `http://127.0.0.1:8081/transaction_view/summary`